### PR TITLE
[Command] Add EditChannels Command

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ all | Generate a random number of sentences from all opted in user messages | `m
 allstats | Display statistics for all users | `mimic!allstats`
 channels | Lists all readable channels | `mimic!channels`
 channels.add | Adds a channel. Default to read only access | `mimic!channels add 123456789 -r -w`
+channels.edit | Edits added channel permissions. Collects user message history if read permission granted and deletes it if revoked. | `mimic!channels edit 123456789`
 channels.full | Lists all channels registered | `mimic!channels full`
 channels.remove | Removes a channel from the database. All related messages are also removed. | `mimic!channels remove 123456789`
 help | show all commands or detailed help of one command | `mimic!help` or `mimic!help about`

--- a/src/main/java/uk/co/markg/mimic/command/AddChannels.java
+++ b/src/main/java/uk/co/markg/mimic/command/AddChannels.java
@@ -29,7 +29,7 @@ public class AddChannels {
   @ParsedEntity
   static class ChannelRequest {
     @Flag(shortName = 'r', longName = "read",
-        description = "Whether the bot should read from the channel. Defaults to true")
+        description = "Whether the bot should read from the channel. Defaults to false")
     Boolean read = Boolean.FALSE;
 
     @Flag(shortName = 'w', longName = "write",
@@ -61,7 +61,7 @@ public class AddChannels {
    * Method held by Disparse to begin command execution
    */
   @CommandHandler(commandName = "channels.add",
-      description = "Add channels. Defaults to read access only.",
+      description = "Add channels. Allows configurable read and write permissions.",
       perms = AbstractPermission.BAN_MEMBERS)
   public void executeAdd() {
     this.execute();

--- a/src/main/java/uk/co/markg/mimic/command/AddChannels.java
+++ b/src/main/java/uk/co/markg/mimic/command/AddChannels.java
@@ -2,7 +2,6 @@ package uk.co.markg.mimic.command;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import disparse.discord.AbstractPermission;
@@ -15,7 +14,6 @@ import net.dv8tion.jda.api.entities.TextChannel;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import uk.co.markg.mimic.database.ChannelRepository;
 import uk.co.markg.mimic.database.UserRepository;
-import uk.co.markg.mimic.db.tables.pojos.Users;
 
 public class AddChannels {
   private static final Logger logger = LogManager.getLogger(AddChannels.class);

--- a/src/main/java/uk/co/markg/mimic/command/AddChannels.java
+++ b/src/main/java/uk/co/markg/mimic/command/AddChannels.java
@@ -107,7 +107,8 @@ public class AddChannels {
    * @param channel The target channel
    */
   private void retrieveChannelHistory(TextChannel channel) {
-    var userids = userRepo.getAll().stream().map(Users::getUserid).collect(Collectors.toList());
+    var serverid = channel.getGuild().getIdLong();
+    var userids = userRepo.getAllUserids(serverid);
     logger.info("Found {} users", userids.size());
     new HistoryGrabber(channel, userids).execute();
   }

--- a/src/main/java/uk/co/markg/mimic/command/EditChannels.java
+++ b/src/main/java/uk/co/markg/mimic/command/EditChannels.java
@@ -87,8 +87,9 @@ public class EditChannels {
           var userids = userRepo.getAllUserids(serverid);
           new HistoryGrabber(textChannel, userids).execute();
         }
-        if (!channelRepo.hasReadPermission(channelidLong) && currentRead)
+        if (!channelRepo.hasReadPermission(channelidLong) && currentRead) {
           messageRepo.deleteByChannelId(channelidLong);
+        }
       } else {
         badChannels.add(channelid);
       }

--- a/src/main/java/uk/co/markg/mimic/command/EditChannels.java
+++ b/src/main/java/uk/co/markg/mimic/command/EditChannels.java
@@ -47,7 +47,8 @@ public class EditChannels {
   /**
    * Command execution method held by Disparse
    */
-  @CommandHandler(commandName = "channels.edit", description = "Edit channels on database.",
+  @CommandHandler(commandName = "channels.edit",
+      description = "Edits added channel permissions. Collects user message history if read permission granted and deletes it if revoked.",
       perms = AbstractPermission.BAN_MEMBERS)
   public void executeEdit() {
     this.execute();

--- a/src/main/java/uk/co/markg/mimic/command/EditChannels.java
+++ b/src/main/java/uk/co/markg/mimic/command/EditChannels.java
@@ -1,0 +1,84 @@
+package uk.co.markg.mimic.command;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import disparse.discord.AbstractPermission;
+import disparse.discord.jda.DiscordRequest;
+import disparse.parser.reflection.CommandHandler;
+import disparse.parser.reflection.Populate;
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
+import uk.co.markg.mimic.command.AddChannels.ChannelRequest;
+import uk.co.markg.mimic.database.ChannelRepository;
+import uk.co.markg.mimic.database.UserRepository;
+import uk.co.markg.mimic.db.tables.pojos.Users;
+
+public class EditChannels {
+
+  private MessageReceivedEvent event;
+  private ChannelRequest req;
+  private ChannelRepository channelRepo;
+  private UserRepository userRepo;
+  private List<String> args;
+
+  /**
+   * Command execution method held by Disparse
+   *
+   */
+  @Populate
+  public EditChannels(DiscordRequest request, ChannelRequest req, ChannelRepository channelRepo,
+      UserRepository userRepo) {
+    this.event = request.getEvent();
+    this.req = req;
+    this.channelRepo = channelRepo;
+    this.userRepo = userRepo;
+    this.args = request.getArgs();
+  }
+
+  /**
+   * Command execution method held by Disparse
+   */
+  @CommandHandler(commandName = "channels.edit", description = "Edit channels on database.",
+      perms = AbstractPermission.BAN_MEMBERS)
+
+  public void executeEdit() {
+    this.execute();
+  }
+
+  /**
+   * Executes the command. Adds any valid channels to the database. Sends a confirmation message to
+   * discord.
+   */
+  private void execute() {
+    String response = editChannels();
+    event.getChannel().sendMessage(response).queue();
+  }
+
+
+  private String editChannels() {
+    var badChannels = new ArrayList<String>();
+    for (String channelid : args) {
+      var textChannel = event.getJDA().getTextChannelById(channelid);
+      var channelidLong = Long.parseLong(channelid);
+      boolean channelExists = channelRepo.isChannelAdded(channelidLong);
+
+      if (textChannel != null && channelExists) {
+        channelRepo.updatePermissions(channelidLong, req.read, req.write);
+
+        if (channelRepo.hasReadPermission(channelidLong)) {
+          var userids =
+              userRepo.getAll().stream().map(Users::getUserid).collect(Collectors.toList());
+          new HistoryGrabber(textChannel, userids).execute();
+        } else {
+          channelRepo.delete(channelid);
+        }
+      } else {
+        badChannels.add(channelid);
+      }
+    }
+
+    return badChannels.isEmpty() ? "All input channels succesfully edited"
+        : "Ignored arguments: " + String.join(",", badChannels);
+  }
+
+}

--- a/src/main/java/uk/co/markg/mimic/command/EditChannels.java
+++ b/src/main/java/uk/co/markg/mimic/command/EditChannels.java
@@ -2,7 +2,6 @@ package uk.co.markg.mimic.command;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 import disparse.discord.AbstractPermission;
 import disparse.discord.jda.DiscordRequest;
 import disparse.parser.reflection.CommandHandler;
@@ -12,7 +11,6 @@ import uk.co.markg.mimic.command.AddChannels.ChannelRequest;
 import uk.co.markg.mimic.database.ChannelRepository;
 import uk.co.markg.mimic.database.MessageRepository;
 import uk.co.markg.mimic.database.UserRepository;
-import uk.co.markg.mimic.db.tables.pojos.Users;
 
 public class EditChannels {
 
@@ -25,7 +23,15 @@ public class EditChannels {
 
   /**
    * Command execution method held by Disparse
-   *
+   * 
+   * @param request     The discord request dispatched to this command
+   * @param req         The parsed flags passed with the command
+   * @param channelRepo The {@link uk.co.markg.mimic.database.ChannelRepository ChannelRepository}
+   *                    instance
+   * @param userRepo    The {@link uk.co.markg.mimic.database.UserRepository UserRepository}
+   *                    instance
+   * @param messageRepo The {@link uk.co.markg.mimic.database.MessageRepository MessageRepository}
+   *                    instance
    */
   @Populate
   public EditChannels(DiscordRequest request, ChannelRequest req, ChannelRepository channelRepo,
@@ -43,20 +49,26 @@ public class EditChannels {
    */
   @CommandHandler(commandName = "channels.edit", description = "Edit channels on database.",
       perms = AbstractPermission.BAN_MEMBERS)
-
   public void executeEdit() {
     this.execute();
   }
 
   /**
-   * Executes the command. Adds any valid channels to the database. Sends a confirmation message to
-   * discord.
+   * Executes the command. Edits any valid channels and updates database. Sends a confirmation
+   * message to discord.
    */
   private void execute() {
     String response = editChannels();
     event.getChannel().sendMessage(response).queue();
   }
 
+  /**
+   * Takes all channelids passed in and overwrites permissions in the database. Collects user
+   * message history of all users for each channel if read permission granted and deletes it if
+   * revoked.
+   *
+   * @return The response message to send back to the channel
+   */
 
   private String editChannels() {
     var badChannels = new ArrayList<String>();

--- a/src/main/java/uk/co/markg/mimic/database/ChannelRepository.java
+++ b/src/main/java/uk/co/markg/mimic/database/ChannelRepository.java
@@ -26,8 +26,8 @@ public class ChannelRepository {
   }
 
   /**
-   * Constructs a {@link uk.co.markg.mimic.db.tables.pojos.Channels Channels} Object to save to
-   * the database.
+   * Constructs a {@link uk.co.markg.mimic.db.tables.pojos.Channels Channels} Object to save to the
+   * database.
    * 
    * @param channelid the discord channel id
    * @param read      whether the bot has read access to the channel
@@ -82,6 +82,18 @@ public class ChannelRepository {
   }
 
   /**
+   * Sets bot's read and write permissions to an existing channel in the database.
+   * 
+   * @param channelid the target channel
+   * @param read      whether the bot should have read access to the channel
+   * @param write     whether the bot should have write access to the channel
+   */
+  public void updatePermissions(long channelid, boolean read, boolean write) {
+    dsl.update(CHANNELS).set((CHANNELS.READ_PERM), read).set((CHANNELS.WRITE_PERM), write)
+        .where(CHANNELS.CHANNELID.eq(channelid)).execute();
+  }
+
+  /**
    * Retrieves all channels in the database
    * 
    * @return list of all channels
@@ -91,7 +103,8 @@ public class ChannelRepository {
   }
 
   public List<Channels> getAllReadable(long serverid) {
-    return dsl.selectFrom(CHANNELS).where(CHANNELS.READ_PERM).and(CHANNELS.SERVERID.eq(serverid)).fetchInto(Channels.class);
+    return dsl.selectFrom(CHANNELS).where(CHANNELS.READ_PERM).and(CHANNELS.SERVERID.eq(serverid))
+        .fetchInto(Channels.class);
   }
 
   /**

--- a/src/main/java/uk/co/markg/mimic/database/ChannelRepository.java
+++ b/src/main/java/uk/co/markg/mimic/database/ChannelRepository.java
@@ -82,7 +82,7 @@ public class ChannelRepository {
   }
 
   /**
-   * Sets bot's read and write permissions to an existing channel in the database.
+   * Updates the bot's read and write permissions to an existing channel in the database.
    * 
    * @param channelid the target channel
    * @param read      whether the bot should have read access to the channel

--- a/src/main/java/uk/co/markg/mimic/database/MessageRepository.java
+++ b/src/main/java/uk/co/markg/mimic/database/MessageRepository.java
@@ -101,6 +101,10 @@ public class MessageRepository {
     return dsl.deleteFrom(MESSAGES).where(MESSAGES.MESSAGEID.eq(messageid)).execute();
   }
 
+  public int deleteByChannelId(long channelid) {
+    return dsl.deleteFrom(MESSAGES).where(MESSAGES.CHANNELID.eq(channelid)).execute();
+  }
+
   public int edit(long messageid, Message newMessage) {
     return dsl.update(MESSAGES).set(MESSAGES.CONTENT, newMessage.getContentRaw())
         .where(MESSAGES.MESSAGEID.eq(messageid)).execute();

--- a/src/main/java/uk/co/markg/mimic/database/UserRepository.java
+++ b/src/main/java/uk/co/markg/mimic/database/UserRepository.java
@@ -4,6 +4,7 @@ import static org.jooq.impl.DSL.count;
 import static uk.co.markg.mimic.db.tables.Messages.MESSAGES;
 import static uk.co.markg.mimic.db.tables.Users.USERS;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.jooq.DSLContext;
 import disparse.parser.reflection.Injectable;
 import uk.co.markg.mimic.db.tables.pojos.Users;
@@ -37,8 +38,12 @@ public class UserRepository {
    * 
    * @return the list of users
    */
-  public List<Users> getAll() {
-    return dsl.selectFrom(USERS).fetchInto(Users.class);
+  public List<Users> getAll(long serverid) {
+    return dsl.selectFrom(USERS).where(USERS.SERVERID.eq(serverid)).fetchInto(Users.class);
+  }
+
+  public List<Long> getAllUserids(long serverid) {
+    return getAll(serverid).stream().map(Users::getUserid).collect(Collectors.toList());
   }
 
   /**

--- a/src/main/java/uk/co/markg/mimic/database/UserRepository.java
+++ b/src/main/java/uk/co/markg/mimic/database/UserRepository.java
@@ -36,12 +36,19 @@ public class UserRepository {
   /**
    * Returns a list of all users in the database
    * 
+   * @param serverid the id of the target server
    * @return the list of users
    */
   public List<Users> getAll(long serverid) {
     return dsl.selectFrom(USERS).where(USERS.SERVERID.eq(serverid)).fetchInto(Users.class);
   }
 
+  /**
+   * Returns a list of all user ids in the database
+   * 
+   * @param serverid the id of the target server
+   * @return the list of users
+   */
   public List<Long> getAllUserids(long serverid) {
     return getAll(serverid).stream().map(Users::getUserid).collect(Collectors.toList());
   }


### PR DESCRIPTION
Added `EditChannels` command that overwrites a channel's read and write permissions and updates the database.

If a channel doesn't have read permission and is granted read permission it will add the message history. If permission is revoked it will delete the message history from the database.